### PR TITLE
libgit2 v1.5.0 #major

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'release-1.2', 'release-1.1', 'release-1.0', 'release-0.28', 'release-0.27' ]
+        branch: [ 'release-1.3', 'release-1.2', 'release-1.1', 'release-1.0', 'release-0.28', 'release-0.27' ]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         libgit2:
-          - 'v1.3.1'
+          - 'v1.5.0'
     name: Go (system-wide, dynamic)
 
     runs-on: ubuntu-20.04

--- a/Build_bundled_static.go
+++ b/Build_bundled_static.go
@@ -10,8 +10,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 3 || LIBGIT2_VER_MINOR > 3
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.3.0 and v1.3.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 5 || LIBGIT2_VER_MINOR > 5
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.5.0 and v1.5.0"
 #endif
 */
 import "C"

--- a/Build_system_dynamic.go
+++ b/Build_system_dynamic.go
@@ -8,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_DYNAMIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 3 || LIBGIT2_VER_MINOR > 3
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.3.0 and v1.3.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 5 || LIBGIT2_VER_MINOR > 5
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.5.0 and v1.5.0"
 #endif
 */
 import "C"

--- a/Build_system_static.go
+++ b/Build_system_static.go
@@ -8,8 +8,8 @@ package git
 #cgo CFLAGS: -DLIBGIT2_STATIC
 #include <git2.h>
 
-#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 3 || LIBGIT2_VER_MINOR > 3
-# error "Invalid libgit2 version; this git2go supports libgit2 between v1.3.0 and v1.3.0"
+#if LIBGIT2_VER_MAJOR != 1 || LIBGIT2_VER_MINOR < 5 || LIBGIT2_VER_MINOR > 5
+# error "Invalid libgit2 version; this git2go supports libgit2 between v1.5.0 and v1.5.0"
 #endif
 */
 import "C"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 git2go
 ======
-[![GoDoc](https://godoc.org/github.com/libgit2/git2go?status.svg)](http://godoc.org/github.com/libgit2/git2go/v33) [![Build Status](https://travis-ci.org/libgit2/git2go.svg?branch=main)](https://travis-ci.org/libgit2/git2go)
+[![GoDoc](https://godoc.org/github.com/libgit2/git2go?status.svg)](http://godoc.org/github.com/libgit2/git2go/v34) [![Build Status](https://travis-ci.org/libgit2/git2go.svg?branch=main)](https://travis-ci.org/libgit2/git2go)
 
 Go bindings for [libgit2](http://libgit2.github.com/).
 
@@ -10,8 +10,9 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 
 | libgit2 | git2go        |
 |---------|---------------|
-| main    | (will be v34) |
-| 1.3     | v33           |
+| main    | (will be v35) |
+| 1.5     | v34           |
+| 1.3     | v34           |
 | 1.2     | v32           |
 | 1.1     | v31           |
 | 1.0     | v30           |
@@ -19,13 +20,13 @@ Due to the fact that Go 1.11 module versions have semantic meaning and don't nec
 | 0.28    | v28           |
 | 0.27    | v27           |
 
-You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.2 installed, you'd import git2go v33 with:
+You can import them in your project with the version's major number as a suffix. For example, if you have libgit2 v1.2 installed, you'd import git2go v34 with:
 
 ```sh
-go get github.com/libgit2/git2go/v33
+go get github.com/libgit2/git2go/v34
 ```
 ```go
-import "github.com/libgit2/git2go/v33"
+import "github.com/libgit2/git2go/v34"
 ```
 
 which will ensure there are no sudden changes to the API.
@@ -49,7 +50,7 @@ This project wraps the functionality provided by libgit2. If you're using a vers
 When linking dynamically against a released version of libgit2, install it via your system's package manager. CGo will take care of finding its pkg-config file and set up the linking. Import via Go modules, e.g. to work against libgit2 v1.2
 
 ```go
-import "github.com/libgit2/git2go/v33"
+import "github.com/libgit2/git2go/v34"
 ```
 
 ### Versioned branch, static linking
@@ -79,7 +80,7 @@ In order to let Go pass the correct flags to `pkg-config`, `-tags static` needs 
 
 One thing to take into account is that since Go expects the `pkg-config` file to be within the same directory where `make install-static` was called, so the `go.mod` file may need to have a [`replace` directive](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive) so that the correct setup is achieved. So if `git2go` is checked out at `$GOPATH/src/github.com/libgit2/git2go` and your project at `$GOPATH/src/github.com/my/project`, the `go.mod` file of `github.com/my/project` might need to have a line like
 
-    replace github.com/libgit2/git2go/v33 => ../../libgit2/git2go
+    replace github.com/libgit2/git2go/v34 => ../../libgit2/git2go
 
 Parallelism and network operations
 ----------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libgit2/git2go/v33
+module github.com/libgit2/git2go/v34
 
 go 1.13
 

--- a/http.go
+++ b/http.go
@@ -38,17 +38,17 @@ func registerManagedHTTP() error {
 
 func httpSmartSubtransportFactory(remote *Remote, transport *Transport) (SmartSubtransport, error) {
 	var proxyFn func(*http.Request) (*url.URL, error)
-	proxyOpts, err := transport.SmartProxyOptions()
+	remoteConnectOpts, err := transport.SmartRemoteConnectOptions()
 	if err != nil {
 		return nil, err
 	}
-	switch proxyOpts.Type {
+	switch remoteConnectOpts.ProxyOptions.Type {
 	case ProxyTypeNone:
 		proxyFn = nil
 	case ProxyTypeAuto:
 		proxyFn = http.ProxyFromEnvironment
 	case ProxyTypeSpecified:
-		parsedUrl, err := url.Parse(proxyOpts.Url)
+		parsedUrl, err := url.Parse(remoteConnectOpts.ProxyOptions.Url)
 		if err != nil {
 			return nil, err
 		}

--- a/remote.go
+++ b/remote.go
@@ -146,6 +146,17 @@ type FetchOptions struct {
 	ProxyOptions ProxyOptions
 }
 
+type RemoteConnectOptions struct {
+	// Proxy options to use for this fetch operation
+	ProxyOptions ProxyOptions
+}
+
+func remoteConnectOptionsFromC(copts *C.git_remote_connect_options) *RemoteConnectOptions {
+	return &RemoteConnectOptions{
+		ProxyOptions: proxyOptionsFromC(&copts.proxy_opts),
+	}
+}
+
 type ProxyType uint
 
 const (
@@ -170,8 +181,8 @@ type ProxyOptions struct {
 	Url string
 }
 
-func proxyOptionsFromC(copts *C.git_proxy_options) *ProxyOptions {
-	return &ProxyOptions{
+func proxyOptionsFromC(copts *C.git_proxy_options) ProxyOptions {
+	return ProxyOptions{
 		Type: ProxyType(copts._type),
 		Url:  C.GoString(copts.url),
 	}

--- a/transport.go
+++ b/transport.go
@@ -84,17 +84,16 @@ type Transport struct {
 	ptr *C.git_transport
 }
 
-// SmartProxyOptions gets a copy of the proxy options for this transport.
-func (t *Transport) SmartProxyOptions() (*ProxyOptions, error) {
+func (t *Transport) SmartRemoteConnectOptions() (*RemoteConnectOptions, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	var cpopts C.git_proxy_options
-	if ret := C.git_transport_smart_proxy_options(&cpopts, t.ptr); ret < 0 {
+	var copts C.git_remote_connect_options
+	if ret := C.git_transport_remote_connect_options(&copts, t.ptr); ret < 0 {
 		return nil, MakeGitError(ret)
 	}
 
-	return proxyOptionsFromC(&cpopts), nil
+	return remoteConnectOptionsFromC(&copts), nil
 }
 
 // SmartCredentials calls the credentials callback for this transport.


### PR DESCRIPTION
Update libgit2 to v1.5.0. Replace with `SmartProxyOptions()` with `SmartRemoteConnectOptions()`.

Related to: https://github.com/libgit2/git2go/issues/899

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>